### PR TITLE
chore: add aws_account_id and domain_name as configurable env variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     needs: []
-    env: {}
+    env:
+      ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
     container: null
     steps:
       - name: Checkout

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -5,10 +5,10 @@ import { Construct } from 'constructs';
 import { WebsiteStack, WebsiteStackProps } from './website';
 
 export const BACKEND_ENV = {
-  account: '458101988253', // prod
+  account: process.env.AWS_ACCOUNT_ID ?? '458101988253', // prod
   region: 'us-east-1',
 };
-const DOMAIN_NAME = 'cli.cdk.dev-tools.aws.dev';
+const DOMAIN_NAME = process.env.DOMAIN_NAME ?? 'cli.cdk.dev-tools.aws.dev';
 
 export class PipelineStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -20,6 +20,10 @@ export class PipelineStack extends Stack {
           'yarn install',
           'yarn build',
         ],
+        env: {
+          ACCOUNT_ID: '${{ secrets.AWS_ACCOUNT_ID }}',
+          DOMAIN_NAME: '${{ secrets.DOMAIN_NAME }}',
+        },
       }),
       gitHubActionRoleArn: `arn:aws:iam::${BACKEND_ENV.account}:role/GitHubActionRole`,
     });


### PR DESCRIPTION
*I have not fully tested this yet*

This should allow for a better development workflow both locally and on a forked repo. To change either the `AWS_ACCOUNT_ID` or `DOMAIN_NAME`, you can add them as environment variables locally and as github secrets on a forked repo. Beware, `cdk synth` must succeed with the dev credentials, so you must have the right aws credentials.