### PR TITLE
chore: mention v1 has entered maintenance and refer to migration guide

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -19,7 +19,7 @@
     {
       "title": "AWS CDK v1 has entered maintenance mode",
       "issueNumber": 19836,
-      "overview": "AWS CDK v1 has entered maintenance mode on June 1, 2022. Migrate to AWS CDK v2 to continue to get the latest features and fixes!\n\n See https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html\n\n To identify existing stacks in your account that were deployed with AWS CDK v1, see https://github.com/cdklabs/awscdk-v1-stack-finder",
+      "overview": "AWS CDK v1 has entered maintenance mode on June 1, 2022. Migrate to AWS CDK v2 to continue to get the latest features and fixes!",
       "components": [
         {
           "name": "framework",


### PR DESCRIPTION
Just some touchups to the already existing notice.