### PR TITLE
fix: change notice to point version

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -7,11 +7,11 @@
       "components": [
         {
           "name": "framework",
-          "version": "2.41.0"
+          "version": ">=2.41.0 <=2.43.0"
         },
         {
           "name": "framework",
-          "version": "1.172.0"
+          "version": ">=1.172.0 <= 1.174.0"
         }
       ],
       "schemaVersion": "1"


### PR DESCRIPTION
The open-ended `>= 1.172.0` makes the error appear for any `2.x` version, which is not intended.

Make the notice appear only for the affected point version, we'll assume the next patch release fixes it.

Fixes #