### PR TITLE
fix: test that version ranges are bounded at the top

### DIFF
--- a/src/notice.ts
+++ b/src/notice.ts
@@ -15,10 +15,6 @@ export interface Notice {
   schemaVersion: string;
 }
 
-export function validateNotices(notices: Notice[]): void {
-  notices.forEach(validateNotice);
-}
-
 /**
  * Validate the notice structure. Constraints:
  *   - Maximum title lenght: 100

--- a/test/notices.test.ts
+++ b/test/notices.test.ts
@@ -1,4 +1,4 @@
-import { validateNotice, validateNotices } from '../src/notice';
+import { validateNotice } from '../src/notice';
 
 test('accepts valid notice', () => {
   expect(() => validateNotice({
@@ -74,8 +74,3 @@ test('rejects notices with empty component arrays', () => {
     schemaVersion: '1',
   })).toThrow(/Notices should specify at least one affected component/);
 });
-
-test('accepts empty notice array', () => {
-  expect(() => validateNotices([])).not.toThrow();
-});
-

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -1,32 +1,42 @@
-import { promises as fs } from 'fs';
+import * as fs from 'fs';
 import { IncomingMessage } from 'http';
 import https from 'https';
 import * as path from 'path';
-import { Notice, validateNotices } from '../src/notice';
+import * as semver from 'semver';
+import { Notice, validateNotice } from '../src/notice';
 
 describe('Notices file is valid', () => {
   let notices: Notice[];
 
-  beforeAll(async () => {
-    const content = await fs.readFile(path.join(__dirname, '../data/notices.json'), 'utf8');
-    notices = JSON.parse(content).notices;
-  });
+  const content = fs.readFileSync(path.join(__dirname, '../data/notices.json'), 'utf8');
+  notices = JSON.parse(content).notices;
 
-  test('Schema is valid', () => {
-    expect(() => validateNotices(notices)).not.toThrow();
-  });
-
-  test('Issue exists', () => {
-    for (const notice of notices) {
-      const url = `https://github.com/aws/aws-cdk/issues/${notice.issueNumber}`;
-      https.get(url, (res: IncomingMessage) => {
-        if (res.statusCode !== 200) {
-          fail(`Couldn't find issue ${url}`);
-        }
-      }).on('error', function(e: Error) {
-        fail(e);
+  notices.forEach(notice => {
+    describe(`notice ${notice.issueNumber}`, () => {
+      test('Validates', () => {
+        validateNotice(notice);
       });
-    }
+
+      test('GitHub issue exists', () => {
+        const url = `https://github.com/aws/aws-cdk/issues/${notice.issueNumber}`;
+        https.get(url, (res: IncomingMessage) => {
+          if (res.statusCode !== 200) {
+            fail(`Couldn't find issue ${url}`);
+          }
+        }).on('error', function(e: Error) {
+          fail(e);
+        });
+      });
+
+      test('all version ranges must be bounded at the top', () => {
+        for (const component of notice.components) {
+          const range = new semver.Range(component.version);
+          if (range.test('100.0.0')) {
+            throw new Error(`${component.version} should contain an upper bound, use <,<=,~ or similar to bound this range`);
+          }
+        }
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Rearchitects the tests a little so that the individual validation failures are clearly scoped and presented by Jest.