### PR TITLE
chore: v1 is not susceptible to the issue actually

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -8,10 +8,6 @@
         {
           "name": "framework",
           "version": ">=2.41.0 <=2.43.0"
-        },
-        {
-          "name": "framework",
-          "version": ">=1.172.0 <= 1.174.0"
         }
       ],
       "schemaVersion": "1"


### PR DESCRIPTION
Its because it stems from stripping deprecated values that we only do for v2.