### PR TITLE
chore: notice for https://github.com/aws/aws-cdk/issues/8607

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -1,6 +1,18 @@
 {
   "notices": [
     {
+      "title": "aws-iam: IAM OIDC provider used with EKS retrieves expiring certificate",
+      "issueNumber": 8607,
+      "overview": "The IAM OIDC provider used with EKS retrieves leaf certificate instead of root certificate which has a longer expiration date",
+      "components": [
+        {
+          "name": "framework",
+          "version": "<=2.49.0"
+        }
+      ],
+      "schemaVersion": "1"
+    },
+    {
       "title": "apigateway: Unable to serialize value as aws-cdk-lib.aws_apigateway.IModel",
       "issueNumber": 21902,
       "overview": "Users of CDK in any language other than TS/JS cannot use values that return an instance of a deprecated class.",

--- a/data/notices.json
+++ b/data/notices.json
@@ -3,11 +3,11 @@
     {
       "title": "aws-iam: IAM OIDC provider used with EKS retrieves expiring certificate",
       "issueNumber": 8607,
-      "overview": "The IAM OIDC provider used with EKS retrieves leaf certificate instead of root certificate which has a longer expiration date",
+      "overview": "An issue in the `aws-iam` module's `OpenIdConnectProvider` may break your application by the end of the year. Please see the issue thread for a workaround if you cannot upgrade when the fix is released.",
       "components": [
         {
           "name": "framework",
-          "version": "<=2.49.0"
+          "version": "<=2.50.0"
         }
       ],
       "schemaVersion": "1"

--- a/data/notices.json
+++ b/data/notices.json
@@ -1,13 +1,17 @@
 {
   "notices": [
     {
-      "title": "aws-iam: IAM OIDC provider used with EKS retrieves expiring certificate",
+      "title": "aws-iam: IAM OIDC provider configures the wrong certificate thumbprint",
       "issueNumber": 8607,
-      "overview": "An issue in the `aws-iam` module's `OpenIdConnectProvider` may break your application by the end of the year. Please see the issue thread for a workaround if you cannot upgrade when the fix is released.",
+      "overview": "Your application is using the iam.OpenIDConnectProvider resource, which currently configures the thumbprint of the leaf certificate instead of the root. Since leaf certificates are rotated more frequently, you are in danger of application errors while trying to use the provider to authenticate against AWS services. See the attached issue for mitigation steps and apply them as soon as possible.",
       "components": [
         {
-          "name": "framework",
-          "version": "<=2.50.0"
+          "name": "iam.OpenIdConnectProvider",
+          "version": "<=2.51.0"
+        },
+        {
+          "name": "iam.OpenIdConnectProvider",
+          "version": "<=1.181.0"
         }
       ],
       "schemaVersion": "1"

--- a/data/notices.json
+++ b/data/notices.json
@@ -3,7 +3,7 @@
     {
       "title": "aws-iam: IAM OIDC provider configures the wrong certificate thumbprint",
       "issueNumber": 8607,
-      "overview": "Your application is using the iam.OpenIDConnectProvider resource, which currently configures the thumbprint of the leaf certificate instead of the root. Since leaf certificates are rotated more frequently, you are in danger of application errors while trying to use the provider to authenticate against AWS services. See the attached issue for mitigation steps and apply them as soon as possible.",
+      "overview": "Your application is using the iam.OpenIDConnectProvider resource, which currently configures the thumbprint of the leaf certificate instead of the root. Since leaf certificates are rotated more frequently, you are in danger of application errors next time those certificates get rotated. See the attached issue for mitigation steps and apply them as soon as possible.",
       "components": [
         {
           "name": "aws-cdk-lib.aws_iam.OpenIdConnectProvider",

--- a/data/notices.json
+++ b/data/notices.json
@@ -6,12 +6,12 @@
       "overview": "Your application is using the iam.OpenIDConnectProvider resource, which currently configures the thumbprint of the leaf certificate instead of the root. Since leaf certificates are rotated more frequently, you are in danger of application errors while trying to use the provider to authenticate against AWS services. See the attached issue for mitigation steps and apply them as soon as possible.",
       "components": [
         {
-          "name": "iam.OpenIdConnectProvider",
-          "version": "<=2.51.0"
+          "name": "aws-cdk-lib.aws-iam.OpenIdConnectProvider",
+          "version": "^2.0.0"
         },
         {
-          "name": "iam.OpenIdConnectProvider",
-          "version": "<=1.181.0"
+          "name": "@aws-cdk/aws-iam.OpenIdConnectProvider",
+          "version": "^1.0.0"
         }
       ],
       "schemaVersion": "1"

--- a/data/notices.json
+++ b/data/notices.json
@@ -6,7 +6,7 @@
       "overview": "Your application is using the iam.OpenIDConnectProvider resource, which currently configures the thumbprint of the leaf certificate instead of the root. Since leaf certificates are rotated more frequently, you are in danger of application errors while trying to use the provider to authenticate against AWS services. See the attached issue for mitigation steps and apply them as soon as possible.",
       "components": [
         {
-          "name": "aws-cdk-lib.aws-iam.OpenIdConnectProvider",
+          "name": "aws-cdk-lib.aws_iam.OpenIdConnectProvider",
           "version": "^2.0.0"
         },
         {


### PR DESCRIPTION
Adding a notice for IAM/EKS OIDC Issue where the OIDC provider currently is retrieving short lived leaf certificates instead of root certificates which have a longer expiration date.