### PR TITLE
chore: upper minor bound for OIDC notice

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -7,11 +7,11 @@
       "components": [
         {
           "name": "aws-cdk-lib.aws_iam.OpenIdConnectProvider",
-          "version": "^2.0.0"
+          "version": "<2.51.0"
         },
         {
           "name": "@aws-cdk/aws-iam.OpenIdConnectProvider",
-          "version": "^1.0.0"
+          "version": "<1.181.0"
         }
       ],
       "schemaVersion": "1"


### PR DESCRIPTION
Now that we have fixed version, we can put a upper bound on the notice. 

See https://github.com/aws/aws-cdk/releases/tag/v2.51.0 and https://github.com/aws/aws-cdk/releases/tag/v1.181.0