### PR TITLE
fix: revert "chore: upper minor bound for OIDC notice"

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -7,11 +7,11 @@
       "components": [
         {
           "name": "aws-cdk-lib.aws_iam.OpenIdConnectProvider",
-          "version": "<2.51.0"
+          "version": "^2.0.0"
         },
         {
           "name": "@aws-cdk/aws-iam.OpenIdConnectProvider",
-          "version": "<1.181.0"
+          "version": "^1.0.0"
         }
       ],
       "schemaVersion": "1"


### PR DESCRIPTION
Reverts cdklabs/aws-cdk-notices#23

This bump caused an HTTP cert & thumbprint miss-match error. Reverting until this is fixed.

Currently blocking:
- https://github.com/cdklabs/aws-cdk-notices/actions/runs/3522519119 

Related TT: V772158739