### PR TITLE
fix: set min aws-cdk version to 2.51.0 so the OIDC thumbprint bug is definitely fixed

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,9 @@
     "*.d.ts",
     "node_modules/",
     "*.generated.ts",
-    "coverage"
+    "coverage",
+    "!.projenrc.ts",
+    "!projenrc/**/*.ts"
   ],
   "rules": {
     "indent": [
@@ -145,7 +147,9 @@
       {
         "devDependencies": [
           "**/test/**",
-          "**/build-tools/**"
+          "**/build-tools/**",
+          ".projenrc.ts",
+          "projenrc/**/*.ts"
         ],
         "optionalDependencies": false,
         "peerDependencies": true

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -25,7 +25,7 @@
     },
     {
       "name": "aws-cdk",
-      "version": "^2.10.0",
+      "version": "^2.51.0",
       "type": "build"
     },
     {
@@ -86,7 +86,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.10.0",
+      "version": "^2.51.0",
       "type": "runtime"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -69,7 +69,7 @@
       "description": "Synthesize project files",
       "steps": [
         {
-          "exec": "node .projenrc.js"
+          "exec": "ts-node --project tsconfig.dev.json .projenrc.ts"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -2,7 +2,7 @@ import { awscdk } from 'projen';
 
 const project = new awscdk.AwsCdkTypeScriptApp({
   projenrcTs: true,
-  cdkVersion: '2.10.0',
+  cdkVersion: '2.51.0',
   defaultReleaseBranch: 'main',
   name: 'aws-cdk-notices',
 

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,5 +1,7 @@
-const { awscdk } = require('projen');
+import { awscdk } from 'projen';
+
 const project = new awscdk.AwsCdkTypeScriptApp({
+  projenrcTs: true,
   cdkVersion: '2.10.0',
   defaultReleaseBranch: 'main',
   name: 'aws-cdk-notices',

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/semver": "^7.3.13",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk": "^2.10.0",
+    "aws-cdk": "^2.51.0",
     "esbuild": "^0.15.16",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
@@ -53,7 +53,7 @@
     "typescript": "~3.9.10"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.10.0",
+    "aws-cdk-lib": "^2.51.0",
     "cdk-pipelines-github": "^0.3.51",
     "constructs": "^10.0.5",
     "semver": "^7.3.8"

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -27,7 +27,9 @@
   "include": [
     ".projenrc.js",
     "src/**/*.ts",
-    "test/**/*.ts"
+    "test/**/*.ts",
+    ".projenrc.ts",
+    "projenrc/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,7 +1159,7 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-cdk-lib@^2.10.0:
+aws-cdk-lib@^2.51.0:
   version "2.53.0"
   resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.53.0.tgz#c36ecfb87ba4e7d1cdfe0c620161beda0ce4aa67"
   integrity sha512-ADpJ9luJxzmOrP/GJ37nA1YtdNmsOsjE+NZnQOpB7YL0spUxZJGNVAselaFLSDZmIsC6d9mSnW81fj4SDP1gAw==
@@ -1177,7 +1177,7 @@ aws-cdk-lib@^2.10.0:
     semver "^7.3.8"
     yaml "1.10.2"
 
-aws-cdk@^2.10.0:
+aws-cdk@^2.51.0:
   version "2.53.0"
   resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.53.0.tgz#97fb88a4ec2473586213f542e1c0ffd2a6d5a365"
   integrity sha512-Tt/H7quNxA/Z0COwHnznnW7+6iJ1oUuJ/dZ5kjPTBtbgMvxRXKzZLDTanlTaET4Q7l6PprQPbUkWkYpka6v0qw==


### PR DESCRIPTION
Fixes the broken `deploy` workflow once deployed.
Also migrates projen config to a ts file.