### PR TITLE
chore: upper minor bound for OIDC notice

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -7,11 +7,11 @@
       "components": [
         {
           "name": "aws-cdk-lib.aws_iam.OpenIdConnectProvider",
-          "version": "^2.0.0"
+          "version": "<2.51.0"
         },
         {
           "name": "@aws-cdk/aws-iam.OpenIdConnectProvider",
-          "version": "^1.0.0"
+          "version": "<1.181.0"
         }
       ],
       "schemaVersion": "1"


### PR DESCRIPTION
We though this change was breaking the deployment. However that was an unrelated failure. So let's add the upper minor  bound again.

Reverts cdklabs/aws-cdk-notices#24
Redo of cdklabs/aws-cdk-notices#23