### PR TITLE
chore: notice for https://github.com/aws/aws-cdk/issues/24668

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -1,9 +1,9 @@
 {
   "notices": [
     {
-      "title": "aws-wafv2: Reverted the naming pattern change where some structs changed from Foo to FooAction",
+      "title": "aws-wafv2: The structs naming pattern changes from FooAction to Foo",
       "issueNumber": 24668,
-      "overview": "Reverted the naming pattern where Allow, Block, Captcha, Challenge and Count struct changed to AllowAction, BlockAction, CaptchaAction, ChallengeAction and CountAction in CloudFormation specification release v109.0.0.",
+      "overview": "The structs naming pattern changes from AllowAction, BlockAction, CaptchaAction, ChallengeAction and CountAction to Allow, Block, Captcha, Challenge and Count respectively.",
       "components": [
         {
           "name": "aws-cdk-lib.aws_wafv2.CfnRuleGroup",

--- a/data/notices.json
+++ b/data/notices.json
@@ -1,6 +1,22 @@
 {
   "notices": [
     {
+      "title": "aws-wafv2: Reverted the naming pattern change where some structs changed from Foo to FooAction",
+      "issueNumber": 24668,
+      "overview": "Reverted the naming pattern where Allow, Block, Captcha, Challenge and Count struct changed to AllowAction, BlockAction, CaptchaAction, ChallengeAction and CountAction in CloudFormation specification release v109.0.0.",
+      "components": [
+        {
+          "name": "aws-cdk-lib.aws_wafv2.CfnRuleGroup",
+          "version": ">=v2.63.0 <v2.70.0"
+        },
+        {
+          "name": "@aws-cdk/aws-wafv2.CfnRuleGroup",
+          "version": ">=v1.192.0 <v1.198.0"
+        }
+      ],
+      "schemaVersion": "1"
+    },
+    {
       "title": "triggers: Deployment of trigger functions fails with a type error",
       "issueNumber": 23407,
       "overview": "The Trigger and TriggerFunction constructs fail to deploy when upgrading.",


### PR DESCRIPTION
CLI notice for WAFv2 RuleGroup struct name changes. 

Being patched here: https://github.com/aws/aws-cdk/pull/24651