### PR TITLE
chore: notice for https://github.com/aws/aws-cdk/issues/25130

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -1,6 +1,18 @@
 {
   "notices": [
     {
+      "title": "core: Names of deployed stacks change, requiring redeployment",
+      "issueNumber": 25130,
+      "overview": "The names of stacks that contain special characters (such as '-') are incorrectly sanitized. This is a breaking change to the names of stacks that have already been deployed.",
+      "components": [
+        {
+          "name": "aws-cdk-lib/core.Stack",
+          "version": ">=v2.74.0 <v2.75.1"
+        }
+      ],
+      "schemaVersion": "1"
+    },
+    {
       "title": "aws-wafv2: The structs naming pattern changes from FooAction to Foo",
       "issueNumber": 24668,
       "overview": "The structs naming pattern changes from AllowAction, BlockAction, CaptchaAction, ChallengeAction and CountAction to Allow, Block, Captcha, Challenge and Count respectively.",


### PR DESCRIPTION
CLI notice for #25130. Stack names have been modified in a breaking way if they use special characters. 