### PR TITLE
chore: notice for https://github.com/aws/aws-cdk/issues/24358

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -1,7 +1,7 @@
 {
   "notices": [
     {
-      "title": "custom-resources: `INACTIVE` custom resource provider lambda throws `State functionActiveV2 is not found`",
+      "title": "custom-resources: `INACTIVE` custom resource provider lambda throws `functionActiveV2 is not found`",
       "issueNumber": 24358,
       "overview": "If the custom resource provider Lambda becomes `INACTIVE`, the custom resource provider framework attempts to call `functionActiveV2()` to wait for the function to become active. This throws the error because the SDK installed by Lambda is at version 2.1055.0, but `functionActiveV2` does not exist until 2.1080.0.",
       "components": [

--- a/data/notices.json
+++ b/data/notices.json
@@ -1,7 +1,7 @@
 {
   "notices": [
     {
-      "title": "custom-resources: `State functionActiveV2 not found` is thrown when using a custom resource whose provider Lambda has become `INACTIVE`",
+      "title": "custom-resources: `INACTIVE` custom resource provider lambda throws `State functionActiveV2 is not found`
       "issueNumber": 24358,
       "overview": "If the custom resource provider Lambda becomes `INACTIVE`, the custom resource provider framework attempts to call `functionActiveV2()` to wait for the function to become active. This throws the error because the SDK installed by Lambda is at version 2.1055.0, but `functionActiveV2` does not exist until 2.1080.0.",
       "components": [

--- a/data/notices.json
+++ b/data/notices.json
@@ -1,7 +1,7 @@
 {
   "notices": [
     {
-      "title": "custom-resources: `INACTIVE` custom resource provider lambda throws `State functionActiveV2 is not found`
+      "title": "custom-resources: `INACTIVE` custom resource provider lambda throws `State functionActiveV2 is not found`",
       "issueNumber": 24358,
       "overview": "If the custom resource provider Lambda becomes `INACTIVE`, the custom resource provider framework attempts to call `functionActiveV2()` to wait for the function to become active. This throws the error because the SDK installed by Lambda is at version 2.1055.0, but `functionActiveV2` does not exist until 2.1080.0.",
       "components": [

--- a/data/notices.json
+++ b/data/notices.json
@@ -1,6 +1,18 @@
 {
   "notices": [
     {
+      "title": "custom-resources: `State functionActiveV2 not found` is thrown when using a custom resource whose provider Lambda has become `INACTIVE`",
+      "issueNumber": 24358,
+      "overview": "If the custom resource provider Lambda becomes `INACTIVE`, the custom resource provider framework attempts to call `functionActiveV2()` to wait for the function to become active. This throws the error because the SDK installed by Lambda is at version 2.1055.0, but `functionActiveV2` does not exist until 2.1080.0.",
+      "components": [
+        {
+          "name": "aws-cdk-lib.custom-resources",
+          "version": ">=v2.60.0 <v2.76.1"
+        }
+      ],
+      "schemaVersion": "1"
+    },
+    {
       "title": "core: Names of deployed stacks change, requiring redeployment",
       "issueNumber": 25130,
       "overview": "The names of stacks that contain special characters (such as '-') are incorrectly sanitized. This is a breaking change to the names of stacks that have already been deployed.",


### PR DESCRIPTION
CLI notice for #24358. Inactive custom resource provider framework lambdas will cause errors due to Lambda's default SDK version (2.1055.0) not having `functionActiveV2` which only exists on 2.1080.0 and up.