### PR TITLE
fix: notices must have non-empty properties

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -1,7 +1,7 @@
 {
   "notices": [
     {
-      "title": "",
+      "title": "stepfunctions-tasks: BedrockInvokeModel outputPath no longer passes output to next state",
       "issueNumber": 31302,
       "overview": "Previously, the BedrockInvokeModel outputPath parameter could be used to select a portion of the model output to pass to the next state. Now, the outputPath parameter is assumed to be an S3Uri where the model output should be saved. The parameter can no longer be used to select model output and pass it to the next state.",
       "components": [

--- a/src/notice.ts
+++ b/src/notice.ts
@@ -18,11 +18,16 @@ export interface Notice {
 
 /**
  * Validate the notice structure. Constraints:
+ *   - No empty properties
  *   - Maximum title length: 100
  *   - Valid component names: 'cli', 'framework'
  *   - Versions comply with the semver format
  */
 export function validateNotice(notice: Notice): void {
+  if (notice.title.length == 0 || notice.overview.length == 0 || notice.schemaVersion.length == 0) {
+    throw new Error('Notices should have non-empty properties');
+  }
+
   if (notice.title.length > MAX_TITLE_LENGTH) {
     throw new Error(`Maximum allowed title length is ${MAX_TITLE_LENGTH}. Title ${notice.title} is ${notice.title.length} characters long`);
   }


### PR DESCRIPTION
adds a check and fixes a bad notice.