### PR TITLE
chore: notice for https://github.com/aws/aws-cdk/pull/33460

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -791,6 +791,18 @@
         }
       ],
       "schemaVersion": "1"
+    },
+    {
+      "title": "(aspects): TagAspect execution order has changed",
+      "issueNumber": 33460,
+      "overview": "Update to priority of Tags may cause Aspects to be executed in different order",
+      "components": [
+        {
+          "name": "aws-cdk-lib.core.Tag",
+          "version": ">=2.181.0 <=2.186.0"
+        }
+      ],
+      "schemaVersion": "1"
     }
   ]
 }


### PR DESCRIPTION
This isn't a regression notice but rather a proactive notice for customers who migrate to CDK v2.181.0 may see a different order of execution in Aspects because we fixed a bug in https://github.com/aws/aws-cdk/pull/33460. I have selected the next 5 versions as an arbitrary cut off point following the precedent set in https://github.com/cdklabs/aws-cdk-notices/pull/751