### PR TITLE
chore: add notice about Cognito Identity Pools soon to be GA

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -6,8 +6,8 @@
       "overview": "We will be moving the Cognito Identity Pools module out of developer preview and into GA some time soon. Before we do, please upgrade to the latest version of CDK to ensure you are using the most stable version of the construct library.",
       "components": [
         {
-          "name": "@aws-cdk.aws_cognito_identitypool_alpha.IdentityPool",
-          "version": ">2.74.0 <=2.179.0"
+          "name": "@aws-cdk/aws-cognito-identitypool-alpha.IdentityPool",
+          "version": ">=2.74.0 <=2.179.0"
         }
       ],
       "schemaVersion": "1"

--- a/data/notices.json
+++ b/data/notices.json
@@ -7,7 +7,7 @@
       "components": [
         {
           "name": "@aws-cdk.aws_cognito_identitypool_alpha.IdentityPool",
-          "version": "<=2.179.0"
+          "version": ">2.74.0 <=2.179.0"
         }
       ],
       "schemaVersion": "1"

--- a/data/notices.json
+++ b/data/notices.json
@@ -3,7 +3,7 @@
     {
       "title": "cognito-identitypool-alpha: Stabilizing to GA soon.",
       "issueNumber": 27483,
-      "overview": "We will be moving the Cognito Identity Pools module out of developer preview and into GA some time soon. Before we do, please upgrade to the latest version of CDK to ensure you are using the most stable version of the construct library.",
+      "overview": "We will be moving the Cognito Identity Pools module out of developer preview and into GA some time soon. Please be advised that we have made some breaking changes to the library, such as the removal of the IdentityPoolRoleAttachment L2 construct. Please upgrade to the latest version of CDK and provide feedback if you encounter any issues.",
       "components": [
         {
           "name": "@aws-cdk/aws-cognito-identitypool-alpha.IdentityPool",

--- a/data/notices.json
+++ b/data/notices.json
@@ -1,6 +1,18 @@
 {
   "notices": [
     {
+      "title": "cognito-identitypool-alpha: Stabilizing to GA soon.",
+      "issueNumber": 27483,
+      "overview": "We will be moving the Cognito Identity Pools module out of developer preview and into GA some time soon. Before we do, please upgrade to the latest version of CDK to ensure you are using the most stable version of the construct library.",
+      "components": [
+        {
+          "name": "@aws-cdk.aws_cognito_identitypool_alpha.IdentityPool",
+          "version": ">=2.164.0 <=2.179.0"
+        }
+      ],
+      "schemaVersion": "1"
+    },
+    {
       "title": "ECR: Cannot use Fn::ImportValue to create repository URI.",
       "issueNumber": 32238,
       "overview": "When using Fn::ImportValue to create a repository URI, the error message 'Template error: Cannot use Fn::ImportValue in Conditions' is thrown.",

--- a/data/notices.json
+++ b/data/notices.json
@@ -7,7 +7,7 @@
       "components": [
         {
           "name": "@aws-cdk.aws_cognito_identitypool_alpha.IdentityPool",
-          "version": ">=2.164.0 <=2.179.0"
+          "version": "<=2.179.0"
         }
       ],
       "schemaVersion": "1"

--- a/data/notices.json
+++ b/data/notices.json
@@ -3,7 +3,7 @@
     {
       "title": "cognito-identitypool-alpha: Stabilizing to GA soon.",
       "issueNumber": 27483,
-      "overview": "We will be moving the Cognito Identity Pools module out of developer preview and into GA some time soon. Please be advised that we have made some breaking changes to the library, such as the removal of the IdentityPoolRoleAttachment L2 construct. Please upgrade to the latest version of CDK and provide feedback if you encounter any issues.",
+      "overview": "The AWS CDK team is preparing to graduate the Cognito Identity Pools module from Developer Preview to General Availability (GA). To ensure uninterrupted functionality of your applications during this transition, we strongly recommend upgrading to the latest version of AWS CDK before this change takes effect.",
       "components": [
         {
           "name": "@aws-cdk/aws-cognito-identitypool-alpha.IdentityPool",


### PR DESCRIPTION
Send out notice to any customers currently using versions of the construct before its latest iteration (pre-2.179.0) to bump to latest and ensure we have decent adoption and coverage.