### PR TITLE
chore: add notice about Scheduler alpha modules soon to be GA

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -1,6 +1,18 @@
 {
   "notices": [
     {
+      "title": "scheduler-alpha and scheduler-targets-alpha: Stabilizing to GA soon.",
+      "issueNumber": 31785,
+      "overview": "The AWS CDK team is preparing to graduate the Scheduler and Scheduler Targets modules from Developer Preview to General Availability (GA). To ensure uninterrupted functionality of your applications during this transition, we strongly recommend upgrading to the latest version of AWS CDK before this change takes effect.",
+      "components": [
+        {
+          "name": "@aws-cdk/aws-scheduler-alpha.Schedule",
+          "version": ">=2.80.0-alpha.0 <=2.181.0-alpha.0"
+        }
+      ],
+      "schemaVersion": "1"
+    },
+    {
       "title": "cognito-identitypool-alpha: Stabilizing to GA soon.",
       "issueNumber": 27483,
       "overview": "The AWS CDK team is preparing to graduate the Cognito Identity Pools module from Developer Preview to General Availability (GA). To ensure uninterrupted functionality of your applications during this transition, we strongly recommend upgrading to the latest version of AWS CDK before this change takes effect.",


### PR DESCRIPTION
Notify users of the construct to upgrade their CDK version for awareness and to minimize disruption when the modules are graduated. 