### PR TITLE
feat: notice for https://github.com/aws/aws-cdk/issues/34205

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -863,6 +863,18 @@
         }
       ],
       "schemaVersion": "1"
+    },
+    {
+      "title": "(cli): all commands failing on Node.js < 18.18.0 with error `Symbol.asyncDispose is not defined`",
+      "issueNumber": 34205,
+      "overview": "Versions 2.1008.0 and 2.1009.0 of the AWS CDK CLI are incompatible with any Node.js version that doesn't support the `asyncDispose` Symbol (that is any version < 18.18.0). Under these circumstances, all CLI commands will fail.",
+      "components": [
+        {
+          "name": "cli",
+          "version": "2.1008.0 || 2.1009.0"
+        }
+      ],
+      "schemaVersion": "1"
     }
   ]
 }


### PR DESCRIPTION
Includes a fix to tests not actually failing if an issue doesn't exists.

Also changes that check to allow a redirect status. This is needed because `https://github.com/aws/aws-cdk/issues/34205` has been transferred to `aws/aws-cdk-cli` and will return a redirect response.