### PR TITLE
chore: update notice 34892

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -3,7 +3,7 @@
     {
       "title": "cli: the CDK CLI will begin to collect telemetry data on CLI usage on or after August 8, 2025.",
       "issueNumber": 34892,
-      "overview": "We do not collect customer content and we anonymize the telemetry we do collect. See the attached issue for more information on what data is collected, why, and how to opt-out.",
+      "overview": "We do not collect customer content and we anonymize the telemetry we do collect. See the attached issue for more information on what data is collected, why, and how to opt-out. Telemetry will NOT be collected for any CDK version released prior to Aug 8 - regardless of opt-in/out.",
       "components": [
         {
           "name": "cli",

--- a/data/notices.json
+++ b/data/notices.json
@@ -3,7 +3,7 @@
     {
       "title": "cli: the CDK CLI will begin to collect telemetry data on CLI usage on or after August 8, 2025.",
       "issueNumber": 34892,
-      "overview": "We do not collect customer content and we anonymize the telemetry we do collect. See the attached issue for more information on what data is collected, why, and how to opt-out. Telemetry will NOT be collected for any CDK version released prior to Aug 8 - regardless of opt-in/out.",
+      "overview": "We do not collect customer content and we anonymize the telemetry we do collect. See the attached issue for more information on what data is collected, why, and how to opt-out. Telemetry will NOT be collected for any CDK CLI version released prior to Aug 8 - regardless of opt-in/out.",
       "components": [
         {
           "name": "cli",


### PR DESCRIPTION
Notice is sent to everyone for visibility so make it clear that telemetry is collected on new versions after 8/8/25 only.