### PR TITLE
chore: update notice 34892

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -1,7 +1,7 @@
 {
   "notices": [
     {
-      "title": "CDK CLI will collect telemetry data on command usage starting from version 2.1100.0 (unless opted out)",
+      "title": "CDK CLI will collect telemetry data on command usage starting at version 2.1100.0 (unless opted out)",
       "issueNumber": 34892,
       "overview": "We do not collect customer content and we anonymize the telemetry we do collect. See the attached issue for more information on what data is collected, why, and how to opt-out. Telemetry will NOT be collected for any CDK CLI version prior to version 2.1100.0 - regardless of opt-in/out.",
       "components": [

--- a/data/notices.json
+++ b/data/notices.json
@@ -1,9 +1,9 @@
 {
   "notices": [
     {
-      "title": "cli: the CDK CLI will begin to collect telemetry data on CLI usage in version 2.1100.0 (unless opted out).",
+      "title": "CDK CLI will collect telemetry data on command usage starting from version 2.1100.0 (unless opted out)",
       "issueNumber": 34892,
-      "overview": "We do not collect customer content and we anonymize the telemetry we do collect. See the attached issue for more information on what data is collected, why, and how to opt-out. Telemetry will NOT be collected for any CDK CLI version released prior to version 2.1100.0 - regardless of opt-in/out.",
+      "overview": "We do not collect customer content and we anonymize the telemetry we do collect. See the attached issue for more information on what data is collected, why, and how to opt-out. Telemetry will NOT be collected for any CDK CLI version prior to version 2.1100.0 - regardless of opt-in/out.",
       "components": [
         {
           "name": "cli",

--- a/data/notices.json
+++ b/data/notices.json
@@ -1,9 +1,9 @@
 {
   "notices": [
     {
-      "title": "cli: the CDK CLI will begin to collect telemetry data on CLI usage on or after August 8, 2025.",
+      "title": "cli: the CDK CLI will begin to collect telemetry data on CLI usage in version 2.1100.0 (unless opted out).",
       "issueNumber": 34892,
-      "overview": "We do not collect customer content and we anonymize the telemetry we do collect. See the attached issue for more information on what data is collected, why, and how to opt-out. Telemetry will NOT be collected for any CDK CLI version released prior to Aug 8 - regardless of opt-in/out.",
+      "overview": "We do not collect customer content and we anonymize the telemetry we do collect. See the attached issue for more information on what data is collected, why, and how to opt-out. Telemetry will NOT be collected for any CDK CLI version released prior to version 2.1100.0 - regardless of opt-in/out.",
       "components": [
         {
           "name": "cli",


### PR DESCRIPTION
Make it clear that telemetry is only collected on future versions 2.1100.0 and above.