### PR TITLE
chore: update notice 34892 with information on how to log telemetry to a local file

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -3,7 +3,7 @@
     {
       "title": "CDK CLI will collect telemetry data on command usage starting at version 2.1100.0 (unless opted out)",
       "issueNumber": 34892,
-      "overview": "We do not collect customer content and we anonymize the telemetry we do collect. See the attached issue for more information on what data is collected, why, and how to opt-out. Telemetry will NOT be collected for any CDK CLI version prior to version 2.1100.0 - regardless of opt-in/out.",
+      "overview": "We do not collect customer content and we anonymize the telemetry we do collect. See the attached issue for more information on what data is collected, why, and how to opt-out. Telemetry will NOT be collected for any CDK CLI version prior to version 2.1100.0 - regardless of opt-in/out. You can also preview the telemetry we will start collecting by logging it to a local file, by adding `--unstable=telemetry --telemetry-file=my/local/file` to any `cdk` command.",
       "components": [
         {
           "name": "cli",


### PR DESCRIPTION
Adds information about https://github.com/aws/aws-cdk-cli/pull/631.