### PR TITLE
chore: remove telemetry cli notice for new cli versions

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -19,7 +19,7 @@
       "components": [
         {
           "name": "cli",
-          "version": "^2.1100.0"
+          "version": ">=2.1100.0 <2.1106.1"
         }
       ],
       "schemaVersion": "1"


### PR DESCRIPTION
we don't aim to have longstanding notices, as they are a nuisance. now that telemetry is launched and those that need to know, know, we are removing the notice for subsequent cli versions.