### PR TITLE
feat: add language component support for CDK app language targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Component structure:
   `@aws-cdk/core`, in case of v1 or `aws-cdk-lib` in case of v2.
 * The reserved word `bootstrap`. This will match against the bootstrap stack version in each
   environment `cdk deploy` runs against. These will only be displayed when running `cdk deploy`.
-* Language components like `language-typescript`, `language-javascript`, `language-python`,
-  `language-java`, `language-dotnet`, or `language-go`. These match against the detected
+* Language components like `language:typescript`, `language:javascript`, `language:python`,
+  `language:java`, `language:dotnet`, or `language:go`. These match against the detected
   CDK app language. Use version `*` since languages don't have versions.
 
 [semver]: https://www.npmjs.com/package/semver
@@ -69,7 +69,7 @@ Some notices can include special strings that dynamically resolve to values duri
 | Key                      | Description                       | component    | example                                               |
 | ------------------------ | --------------------------------- | ------------ | ----------------------------------------------------- |
 | `{resolve:ENVIRONMENTS}` | List of bootstrapped environments | `bootstrap`  | aws://1234567890/us-east-1,aws://1234567890/us-east-2 |
-| `{resolve:LANGUAGE}`     | Display name of detected language | `language-*` | TypeScript, Java, etc.                                |
+| `{resolve:LANGUAGE}`     | Display name of detected language | `language:*` | TypeScript, Java, etc.                                |
 
 ## FAQ
 

--- a/src/construct-info.ts
+++ b/src/construct-info.ts
@@ -1,4 +1,4 @@
-export const SPECIAL_COMPONENTS = ['bootstrap', 'node', 'language-typescript', 'language-javascript', 'language-python', 'language-java', 'language-dotnet', 'language-go'];
+export const SPECIAL_COMPONENTS = ['bootstrap', 'node', 'language:typescript', 'language:javascript', 'language:python', 'language:java', 'language:dotnet', 'language:go'];
 
 export const CONSTRUCT_INFO = [
   'aws-cdk-lib.aws_elasticsearch',

--- a/src/notice.ts
+++ b/src/notice.ts
@@ -37,8 +37,8 @@ export function validateNotice(notice: Notice): void {
   }
 
   // Check language component constraints
-  const languageComponents = notice.components.filter(c => c.name.startsWith('language-'));
-  const nonLanguageComponents = notice.components.filter(c => !c.name.startsWith('language-'));
+  const languageComponents = notice.components.filter(c => c.name.startsWith('language:'));
+  const nonLanguageComponents = notice.components.filter(c => !c.name.startsWith('language:'));
 
   if (languageComponents.length > 0 && nonLanguageComponents.length === 0) {
     throw new Error('Language components cannot be used alone; combine with another component like cli or framework');
@@ -52,7 +52,7 @@ export function validateNotice(notice: Notice): void {
 
   for (const component of notice.components) {
     // Skip semver validation for language components (they use '*')
-    if (!component.name.startsWith('language-') && !isValidComponentVersion(component.version)) {
+    if (!component.name.startsWith('language:') && !isValidComponentVersion(component.version)) {
       throw new Error(`Component version ${component.version} is not a valid semver range`);
     }
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -36,7 +36,7 @@ describe('Notices file is valid', () => {
       test('all version ranges must be bounded at the top', () => {
         for (const component of notice.components) {
           // Language components use '*' which is unbounded by design
-          if (component.name.startsWith('language-')) { continue; }
+          if (component.name.startsWith('language:')) { continue; }
 
           const range = new semver.Range(component.version);
           if (!isBoundedFromAbove(range)) {


### PR DESCRIPTION
Currently, CDK notices can only target users based on the packages they use or their bootstrap version. However, some issues are language-specific and only affect users of certain programming languages. For example, a Python-specific jsii bug or a TypeScript compilation issue would not be relevant to Java users.

This change introduces language components (`language-typescript`, `language-javascript`, `language-python`, `language-java`, `language-dotnet`, `language-go`) that allow notice authors to target specific CDK app languages. The CLI will match these against the detected language of the user's CDK app.

Language components are designed to be used in combination with other components like `cli` or `framework`, rather than standalone. This ensures notices remain scoped to a meaningful context. Since programming languages don't have versions in the traditional sense, language components must use `*` as their version.

The `{resolve:LANGUAGE}` placeholder is also documented, which allows notice messages to dynamically include the detected language name for clearer communication to users.
