### PR TITLE
fix: add notice for https://github.com/aws/aws-cdk/issues/37041

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,32 @@ Component structure:
 
 [semver]: https://www.npmjs.com/package/semver
 
-Example:
+### Combining components
+
+The `components` field is evaluated in [Disjunctive Normal Form][dnf] (an OR of ANDs):
+
+* A flat list of components is treated as **OR** — the notice matches if *any* component matches.
+* A nested array of components is treated as **AND** — all components in the inner array must match.
+* Multiple nested arrays are combined with **OR** — at least one group must fully match.
+
+For example, to match (.NET AND framework ≤2.238.0) OR (Go AND framework ≤2.238.0):s
+
+```json
+"components": [
+  [
+    { "name": "language:dotnet", "version": "*" },
+    { "name": "framework", "version": "<=2.238.0" }
+  ],
+  [
+    { "name": "language:go", "version": "*" },
+    { "name": "framework", "version": "<=2.238.0" }
+  ]
+]
+```
+
+[dnf]: https://en.wikipedia.org/wiki/Disjunctive_normal_form
+
+### Simple example
 
 ```json
 {

--- a/data/notices.json
+++ b/data/notices.json
@@ -1011,6 +1011,24 @@
         }
       ],
       "schemaVersion": "1"
+    },
+    {
+      "title": "Constructs 10.5.0 incompatible with .NET and Go CDK libraries <=2.238.0",
+      "issueNumber": 37041,
+      "overview": "Constructs 10.5.0 introduced changes that require updated language bindings. .NET and Go CDK libraries <=2.238.0 are not compatible with this release, causing JSII runtime failures during build time. Remain on Constructs 10.4.5 until you can upgrade your CDK library to 2.239.0 or later.",
+      "components": [
+        [
+          { "name": "language:dotnet", "version": "*" },
+          { "name": "framework", "version": ">=2.0.0 <=2.238.0" },
+          { "name": "constructs", "version": "^10.5.0" }
+        ],
+        [
+          { "name": "language:go", "version": "*" },
+          { "name": "framework", "version": ">=2.0.0 <=2.238.0" },
+          { "name": "constructs", "version": "^10.5.0" }
+        ]
+      ],
+      "schemaVersion": "1"
     }
   ]
 }

--- a/src/notice.ts
+++ b/src/notice.ts
@@ -12,7 +12,7 @@ export interface Notice {
   title: string;
   issueNumber: number;
   overview: string;
-  components: Component[];
+  components: Array<Component | Component[]>;
   schemaVersion: string;
 }
 
@@ -36,9 +36,11 @@ export function validateNotice(notice: Notice): void {
     throw new Error('Notices should specify at least one affected component');
   }
 
+  const flatComponents = notice.components.flat();
+
   // Check language component constraints
-  const languageComponents = notice.components.filter(c => c.name.startsWith('language:'));
-  const nonLanguageComponents = notice.components.filter(c => !c.name.startsWith('language:'));
+  const languageComponents = flatComponents.filter(c => c.name.startsWith('language:'));
+  const nonLanguageComponents = flatComponents.filter(c => !c.name.startsWith('language:'));
 
   if (languageComponents.length > 0 && nonLanguageComponents.length === 0) {
     throw new Error('Language components cannot be used alone; combine with another component like cli or framework');
@@ -50,7 +52,7 @@ export function validateNotice(notice: Notice): void {
     }
   }
 
-  for (const component of notice.components) {
+  for (const component of flatComponents) {
     // Skip semver validation for language components (they use '*')
     if (!component.name.startsWith('language:') && !isValidComponentVersion(component.version)) {
       throw new Error(`Component version ${component.version} is not a valid semver range`);

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -34,7 +34,7 @@ describe('Notices file is valid', () => {
       });
 
       test('all version ranges must be bounded at the top', () => {
-        for (const component of notice.components) {
+        for (const component of notice.components.flat()) {
           // Language components use '*' which is unbounded by design
           if (component.name.startsWith('language:')) { continue; }
 
@@ -46,7 +46,7 @@ describe('Notices file is valid', () => {
       });
 
       test('v2 version ranges must be bounded at the bottom', () => {
-        for (const component of notice.components) {
+        for (const component of notice.components.flat()) {
           if (component.version === '1.*') { continue; } // Special range that we allow
           if (SPECIAL_COMPONENTS.includes(component.name)) { continue; } // Not subject to v1/v2 ranges
 


### PR DESCRIPTION
https://github.com/aws/aws-cdk/issues/37041

Constructs 10.5.0 introduced changes that require updated JSII language bindings. .NET and Go CDK libraries at version 2.238.0 and below don't have these bindings yet, causing JSII runtime failures at build time. This notice tells affected users to stay on Constructs 10.4.5 until they can upgrade their CDK library to 2.239.0 or later.

The notice uses AND-grouped components to target only the specific combinations that are actually broken, rather than matching all .NET and Go users regardless of their framework version. The components field already supported nested arrays for AND-groups, but this wasn't documented or validated correctly. The README, type definition, and validation logic are updated accordingly.

