### PR TITLE
feat(notice): support per-placeholder rendering options via dynamicValues

### DIFF
--- a/data/notices.json
+++ b/data/notices.json
@@ -786,7 +786,10 @@
           "version": "<21"
         }
       ],
-      "schemaVersion": "1"
+      "schemaVersion": "1",
+      "dynamicValues": {
+        "ENVIRONMENTS": { "separator": " " }
+      }
     },
     {
       "title": "(cli): UnauthorizedException: Session token not found or invalid",

--- a/src/notice.ts
+++ b/src/notice.ts
@@ -8,6 +8,22 @@ export interface Component {
   version: string;
 }
 
+/**
+ * Per-dynamic-value rendering options.
+ *
+ * Fields are optional and purely additive. Unknown fields MUST be ignored by
+ * consumers so new capabilities (prefix, suffix, limit, ...) can be added later
+ * without breaking older CLIs.
+ */
+export interface DynamicValueSpec {
+  /**
+   * String used to join multiple values for the same dynamic name.
+   *
+   * @default ","
+   */
+  readonly separator?: string;
+}
+
 export interface Notice {
   title: string;
   issueNumber: number;
@@ -15,6 +31,17 @@ export interface Notice {
   components: Component[];
   componentsV2?: Array<Component | Component[]>;
   schemaVersion: string;
+
+  /**
+   * Per-placeholder rendering options, keyed by the dynamic name used in
+   * `{resolve:NAME}` placeholders within `overview`.
+   *
+   * Unknown by older CLIs (<= current); they will ignore the field and fall
+   * back to the default separator (`,`).
+   *
+   * @default - no overrides; all placeholders render with default settings
+   */
+  dynamicValues?: Record<string, DynamicValueSpec>;
 }
 
 /**
@@ -110,6 +137,17 @@ export function validateNotice(notice: Notice): void {
 
   if (!semver.validRange(notice.schemaVersion)) {
     throw new Error(`Schema version ${notice.schemaVersion} is not a valid semver range`);
+  }
+
+  if (notice.dynamicValues) {
+    for (const [name, spec] of Object.entries(notice.dynamicValues)) {
+      if (!notice.overview.includes(`{resolve:${name}}`)) {
+        throw new Error(`dynamicValues entry '${name}' has no matching {resolve:${name}} placeholder in overview`);
+      }
+      if (spec.separator !== undefined && typeof spec.separator !== 'string') {
+        throw new Error(`dynamicValues['${name}'].separator must be a string`);
+      }
+    }
   }
 }
 

--- a/test/notices.test.ts
+++ b/test/notices.test.ts
@@ -137,3 +137,26 @@ test('rejects notices with incorrect construct name foo', () => {
     schemaVersion: '1',
   })).toThrow(/Invalid component name foo/);
 });
+
+
+test('accepts dynamicValues with separator for matching placeholder', () => {
+  expect(() => validateNotice({
+    title: 'Bootstrap stack outdated',
+    issueNumber: 31885,
+    overview: 'Rebootstrap by running cdk bootstrap {resolve:ENVIRONMENTS}',
+    components: [{ name: 'bootstrap', version: '<21' }],
+    schemaVersion: '1',
+    dynamicValues: { ENVIRONMENTS: { separator: ' ' } },
+  })).not.toThrow();
+});
+
+test('rejects dynamicValues entry without matching placeholder', () => {
+  expect(() => validateNotice({
+    title: 'Bootstrap stack outdated',
+    issueNumber: 31885,
+    overview: 'No placeholder here',
+    components: [{ name: 'bootstrap', version: '<21' }],
+    schemaVersion: '1',
+    dynamicValues: { ENVIRONMENTS: { separator: ' ' } },
+  })).toThrow(/no matching \{resolve:ENVIRONMENTS\} placeholder/);
+});


### PR DESCRIPTION
Notices today have a single way to render `{resolve:NAME}` placeholders: the CLI substitutes matched values joined by a hardcoded comma. That works fine in prose, but not for placeholders that appear inside an executable command. The most visible case today is the rebootstrap notice, whose suggested command ends up as `cdk bootstrap aws://acct/r1,aws://acct/r2` and fails to parse (see aws/aws-cdk#31963).

Changing the hardcoded separator in the CLI globally would silently alter output for every existing notice that relies on commas in prose, so this takes the notice-side route instead. Each notice can now declare an optional `dynamicValues` map keyed by placeholder name, where each entry is a `DynamicValueSpec` object. Today the spec only carries `separator`, but keeping the value as an object means future options (`prefix`, `suffix`, `limit`, ...) can be added purely additively without another schema change, and older CLIs that don't recognise those fields will simply ignore them.

The field is optional. Older CLIs ignore it entirely and keep the existing comma behavior, so this does not regress anyone — notice authors opt in per placeholder. The validator also checks that every declared `dynamicValues` key has a matching `{resolve:NAME}` placeholder in the overview, so typos and stale entries are caught at authoring time rather than silently dropped at render time.

The rebootstrap notice (issue 31885) is updated to declare `{ ENVIRONMENTS: { separator: " " } }`, which makes new CLIs produce a runnable `cdk bootstrap aws://acct/r1 aws://acct/r2` while older CLIs continue to print the current comma-joined output.

Paired with aws/aws-cdk-cli#TBD in the toolkit.

Fixes aws/aws-cdk#31963
