### PR TITLE
chore: pipeline also needs corepack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Enable corepack
+        run: corepack enable
       - name: Build
         run: |-
           yarn install

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -21,6 +21,7 @@ export class PipelineStack extends Stack {
           'yarn build',
         ],
       }),
+      preBuildSteps: [{ name: 'Enable corepack', run: 'corepack enable' }],
       gitHubActionRoleArn: `arn:aws:iam::${BACKEND_ENV.account}:role/GitHubActionRole`,
     });
 


### PR DESCRIPTION
The deploy workflow is generated by `cdk-pipelines-github` at CDK synth time, not by projen, so it wasn't touched by the Yarn Berry migration in #1088. As a result, the Synth job runs `yarn install` and `yarn build` using whatever Yarn ships on the GitHub runner (Yarn 1) instead of the Yarn version pinned via `packageManager` in `package.json`. That defeats the point of moving to Yarn Berry for the deploy path.

The fix is to add a `corepack enable` step to `preBuildSteps` on the pipeline, which makes Corepack pick up the pinned Yarn version before the install runs.

Fixes #
